### PR TITLE
Fix humidity comparison bug

### DIFF
--- a/air-conditioner/ac-thermostat.cpp
+++ b/air-conditioner/ac-thermostat.cpp
@@ -124,7 +124,7 @@ void ACThermostat::checkHumidity() {
   }
 
   if (
-    (abs(event.temperature - currentHumidity->getVal<float>()) < humid_diff_threshold) &&
+    (abs(event.relative_humidity - currentHumidity->getVal<float>()) < humid_diff_threshold) &&
     (currentHumidity->timeVal() < force_update_interval_ms)
   ) {
     return;

--- a/passive-sensor/humidity-sensor.h
+++ b/passive-sensor/humidity-sensor.h
@@ -37,7 +37,7 @@ struct HumiditySensor : Service::HumiditySensor {
     }
 
     if (
-      (abs(event.temperature - humidity_kit->getVal<float>()) < humid_diff_threshold) &&
+      (abs(event.relative_humidity - humidity_kit->getVal<float>()) < humid_diff_threshold) &&
       (humidity_kit->timeVal() < force_update_interval_ms)
     ) {
       return;


### PR DESCRIPTION
## Summary
- fix checkHumidity comparisons to use humidity in AC thermostat
- fix humidity sensor comparison to use relative humidity value

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683fc0cad35c8333bcf0a62570f729dc